### PR TITLE
docs: add analysis of existing tests

### DIFF
--- a/DD2480/report.md
+++ b/DD2480/report.md
@@ -60,6 +60,8 @@ Optional (point 3): trace tests to requirements.
 
 There doesn't seem to be any tests related to the issue. The file `jabgui/src/main/java/org/jabref/gui/importer/BookCoverFetcher.java`, which is used to fetch book covers, is not covered at all by any tests.
 
+We therefore created some tests that should fail before implementing functionality for the requirements. See `jabgui/src/test/java/org/jabref/gui/importer/BookCoverFetcherTest.java` in the main branch.
+
 ## Code changes
 
 ### Patch


### PR DESCRIPTION
I couldn't find any tests that are related to the issue. I also ran the manual coverage tool from the previous assignment to see if anything calls the constructor for BookCoverFetcher, but didn't find anything.

closes #10 